### PR TITLE
removed merchantID from constructor, updated docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ $token = getenv("MERCHANT_TOKEN_SANDBOX");
 
 $client = new PaymentRequestClient($apiUrl, $token);
 
-// Creating a Payment request
-//  - required fields: amount, currency (default="EUR") and paymentMethodTypes (default="pisp") can be passed to the constructor.
+// Creating a Payment request (payment amount is required).
 $amount = new PreciseNumber("1.11");
 $newPaymentRequest = new PaymentRequestCreate($amount->__toString());
 

--- a/README.md
+++ b/README.md
@@ -17,31 +17,32 @@ composer require nofrixion/moneymoov-php
 
 ## Usage ##
 
-The following example code shows how to use the library to create, updated and delete payment requests (see the [NoFrixion API documentation](https://docs.nofrixion.com/reference/sandbox) for a full MoneyMoov API reference and instructions on signing up for a sandbox account).
+The following example code shows how to use the library to create, update and delete payment requests (see the [NoFrixion API documentation](https://docs.nofrixion.com/reference/sandbox) for a full MoneyMoov API reference and instructions on signing up for a sandbox account).
 
 ```php
 // Client for handling Payment Request API endpoints
 use Nofrixion\Client\PaymentRequestClient;
+
 // Models for creating/updating Payment Requests
 use Nofrixion\Model\PaymentRequests\PaymentRequestCreate;
 use Nofrixion\Model\PaymentRequests\PaymentRequestUpdate;
+
 // Model returned by payment request client on creation/update
 use Nofrixion\Model\PaymentRequests\PaymentRequest;
 
 use Nofrixion\Util\PreciseNumber;
 
 $apiUrl = "https://api-sandbox.nofrixion.com/";
-// A merchant token is required for creating and modifying payment requests
+// A merchant token can be used for creating and modifying payment requests - this MUST be securely stored.
 $token = getenv("MERCHANT_TOKEN_SANDBOX");
 
 $client = new PaymentRequestClient($apiUrl, $token);
 
 // Creating a Payment request
-$merchID = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+//  - required fields: amount, currency (default="EUR") and paymentMethodTypes (default="pisp") can be passed to the constructor.
 $amount = new PreciseNumber("1.11");
+$newPaymentRequest = new PaymentRequestCreate($amount->__toString());
 
-// Required fields merchantID, amount, currency (default="EUR") and paymentMethodTypes (default="pisp") can be passed to the constructor.
-$newPaymentRequest = new PaymentRequestCreate($merchID, $amount->__toString());
 // Additional optional fields can be set directly on PaymentRequestCreate model.
 $newPaymentRequest->shippingFirstName = "Customer";
 $newPaymentRequest->shippingLastName = "Name";
@@ -51,7 +52,7 @@ $newPaymentRequest->baseOriginUrl = "https://store.example.com";
 $result = $client->createPaymentRequest($newPaymentRequest);
 
 
-// use the PaymentRequestUpdate model to update payment request values.
+// UPDATES: use the PaymentRequestUpdate model to update payment request values.
 $update = new PaymentRequestUpdate();
 $update->paymentMethodTypes = 'card, pisp';
 $update->amount = "1.45";
@@ -59,6 +60,6 @@ $update->shippingAddressCity = "Dublin";
 $result = $client->updatePaymentRequest($result->id, $update);
 
 
-// Deleting a rayment request
+// DELETING a payment request
 $deleted = $client->deletePaymentRequest($result->id);
 ```

--- a/src/Model/PaymentRequests/PaymentRequest.php
+++ b/src/Model/PaymentRequests/PaymentRequest.php
@@ -94,6 +94,11 @@ class PaymentRequest
                     $this->addresses = $value;
                     break;
                 case "result":
+                    if (array_key_exists('customerID', $value)){
+                        $customerID = $value['customerID'];
+                    } else {
+                        $customerID = null;
+                    }
                     $this->result = new PaymentRequestResult(
                         $value['paymentRequestID'],
                         $value['amount'],
@@ -102,7 +107,7 @@ class PaymentRequest
                         $value['requestedAmount'],
                         $value['payments'],
                         $value['pispAuthorizations'],
-                        $value['customerID']
+                        $customerID
                     );
                     break;
                 case "shippingAddress":

--- a/src/Model/PaymentRequests/PaymentRequestCreate.php
+++ b/src/Model/PaymentRequests/PaymentRequestCreate.php
@@ -7,12 +7,12 @@ namespace Nofrixion\Model\PaymentRequests;
 use Nofrixion\Util\PreciseNumber;
 
 /**
- * PaymentRequestCreate - use to create payment request, at minimum MerchantID, amount, currency and paymentMethodTypes
+ * PaymentRequestCreate - use to create payment request, at minimum amount, currency and paymentMethodTypes
  *  must be set in constructor. Other properties can be assigned direclty.
  */
 class PaymentRequestCreate
 {
-    public string $merchantID;
+    public ?string $merchantID;
     public string $amount;
     public string $currency;
     public string $paymentMethodTypes;
@@ -55,13 +55,11 @@ class PaymentRequestCreate
     public ?array $tags;
 
     public function __construct(
-        string $merchantID,
         string $amount,
         string $currency = "EUR",
         string $paymentMethodTypes = "pisp"
     )
     {
-        $this->merchantID = $merchantID;
         $this->amount = $amount;
         $this->currency = $currency;
         $this->paymentMethodTypes = $paymentMethodTypes;

--- a/src/Model/PaymentRequests/PaymentRequestCreate.php
+++ b/src/Model/PaymentRequests/PaymentRequestCreate.php
@@ -14,8 +14,8 @@ class PaymentRequestCreate
 {
     public ?string $merchantID;
     public string $amount;
-    public string $currency;
-    public string $paymentMethodTypes;
+    public ?string $currency = null;
+    public ?string $paymentMethodTypes;
     public ?string $CustomerID;
     public ?string $OrderID;
     public ?string $description;
@@ -55,14 +55,9 @@ class PaymentRequestCreate
     public ?array $tags;
 
     public function __construct(
-        string $amount,
-        string $currency = "EUR",
-        string $paymentMethodTypes = "pisp"
+        string $amount
     )
     {
         $this->amount = $amount;
-        $this->currency = $currency;
-        $this->paymentMethodTypes = $paymentMethodTypes;
-        
     }
 }

--- a/src/Model/PaymentRequests/PaymentRequestCreate.php
+++ b/src/Model/PaymentRequests/PaymentRequestCreate.php
@@ -7,8 +7,8 @@ namespace Nofrixion\Model\PaymentRequests;
 use Nofrixion\Util\PreciseNumber;
 
 /**
- * PaymentRequestCreate - use to create payment request, at minimum amount, currency and paymentMethodTypes
- *  must be set in constructor. Other properties can be assigned direclty.
+ * PaymentRequestCreate - use to create payment request.
+ *  `amount` must be set in constructor. Other properties can be assigned directly.
  */
 class PaymentRequestCreate
 {

--- a/src/Model/PaymentRequests/PaymentRequestCreate.php
+++ b/src/Model/PaymentRequests/PaymentRequestCreate.php
@@ -16,8 +16,8 @@ class PaymentRequestCreate
     public string $amount;
     public ?string $currency = null;
     public ?string $paymentMethodTypes;
-    public ?string $CustomerID;
-    public ?string $OrderID;
+    public ?string $customerID;
+    public ?string $orderID;
     public ?string $description;
     public ?string $pispAccountID;
     public ?string $shippingFirstName;


### PR DESCRIPTION
Made two changes following Aaron's feedback that when creating a payment request using a merchant token, the merchantID was not required in the example code :

1. updated the PaymentRequestCreate class so that the `merchantID` was nullable and is not set via the class constructor.
2. fixed the example code in README.md to reflect the above change.
